### PR TITLE
Hide pricing text in the services section

### DIFF
--- a/src/components/landing/Section3.astro
+++ b/src/components/landing/Section3.astro
@@ -21,11 +21,11 @@ import Button from "../ui/Button.astro";
             <span class="sr-only">Plan</span>
           </h2>
           <div>
-            <p class="mt-2 text-gray-700">{service.shortDescription}</p>
-            <p class="mt-2 sm:mt-4 text-right">
+            <p class="mt-2 pb-4 text-gray-700">{service.shortDescription}</p>
+            {/* <p class="mt-2 sm:mt-4 text-right">
               <strong class="text-3xl font-bold text-gray-900 sm:text-5xl">{service.price}</strong>
               <span class="text-xs font-medium text-gray-700">{service.priceUnit}</span>
-            </p>
+            </p> */}
           </div>
           <Button
             type="button"


### PR DESCRIPTION
This commit introduces a change to the services section of the landing page. The pricing information that was previously displayed has been temporarily hidden.