### PR TITLE
Use Astro Image component for responsive assets

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -37,30 +37,55 @@ const fullWhatsappLink = `https://wa.me/${whatsappNumber}`;
               rel="noopener noreferrer"
               target="_blank"
             >
-              <img src={icons.linkedin.src} alt="Linkedin" class="transition duration-200 hover:brightness-120" />
+              <Image
+                src={icons.linkedin}
+                alt="Linkedin"
+                class="transition duration-200 hover:brightness-120"
+                sizes="24px"
+              />
             </a>
           </li>
 
           <li>
             <a href="https://www.youtube.com/user/inode64" rel="noopener noreferrer" target="_blank">
-              <img src={icons.youtube.src} alt="YouTube" class="transition duration-200 hover:brightness-120" />
+              <Image
+                src={icons.youtube}
+                alt="YouTube"
+                class="transition duration-200 hover:brightness-120"
+                sizes="24px"
+              />
             </a>
           </li>
 
           <li>
             <a href="https://twitter.com/inode64" target="_blank" rel="noopener noreferrer">
-              <img src={icons.twitter.src} alt="Twitter" class="transition duration-200 hover:brightness-120" />
+              <Image
+                src={icons.twitter}
+                alt="Twitter"
+                class="transition duration-200 hover:brightness-120"
+                sizes="24px"
+              />
             </a>
           </li>
 
           <li>
             <a href="https://github.com/inode64" rel="noopener noreferrer" target="_blank">
-              <img src={icons.github.src} alt="Github" class="transition duration-200 hover:brightness-110" />
+              <Image
+                src={icons.github}
+                alt="Github"
+                class="transition duration-200 hover:brightness-110"
+                sizes="24px"
+              />
             </a>
           </li>
           <li>
             <a href="https://www.flickr.com/photos/inode64/" rel="noopener noreferrer" target="_blank">
-              <img src={icons.flickr.src} alt="Flickr" class="transition duration-200 hover:brightness-110" />
+              <Image
+                src={icons.flickr}
+                alt="Flickr"
+                class="transition duration-200 hover:brightness-110"
+                sizes="24px"
+              />
             </a>
           </li>
         </ul>
@@ -111,21 +136,36 @@ const fullWhatsappLink = `https://wa.me/${whatsappNumber}`;
 
           <ul class="mt-8 space-y-4 text-sm">
             <li class="-mt-0.5 flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end">
-              <img src={icons.mail.src} alt="Icono de correo" class="max-w-6" />
+              <Image
+                src={icons.mail}
+                alt="Icono de correo"
+                class="max-w-6"
+                sizes="24px"
+              />
               <span class="flex-1 text-gray-700">
                 <ObfuscatedEmail email={import.meta.env.SENDER_CONTACT_EMAIL} />
               </span>
             </li>
 
             <li class="-mt-0.5 flex items-center justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end">
-              <img src={icons.phone.src} alt="Icono de teléfono" class="max-w-6" />
+              <Image
+                src={icons.phone}
+                alt="Icono de teléfono"
+                class="max-w-6"
+                sizes="24px"
+              />
               <span class="flex-1 text-gray-700">
                 <ObfuscatedPhone phone={import.meta.env.PHONE_NUMBER} />
               </span>
             </li>
 
             <li class="-mt-0.5 flex items-start justify-center gap-1.5 ltr:sm:justify-start rtl:sm:justify-end">
-              <img src={icons.location.src} alt="Icono de localización" class="max-w-6" />
+              <Image
+                src={icons.location}
+                alt="Icono de localización"
+                class="max-w-6"
+                sizes="24px"
+              />
               <address class="-mt-0.5 flex-1 text-gray-700 not-italic">
                 {import.meta.env.PUBLIC_ADDRESS}
               </address>

--- a/src/components/landing/Section1.astro
+++ b/src/components/landing/Section1.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import { icons } from "../../assets/icons";
 ---
 
@@ -29,19 +30,21 @@ import { icons } from "../../assets/icons";
         </a>
       </div>
 
-      <img
-        src={icons.welcome.src}
+      <Image
+        src={icons.welcome}
         class="mt-10 h-auto max-h-[520px] w-full max-w-xs sm:max-w-sm mx-auto lg:hidden"
         loading="lazy"
         alt="Ilustración de clúster de servidores"
+        sizes="(max-width: 1024px) 100vw, 50vw"
       />
     </div>
 
-    <img
-      src={icons.welcome.src}
+    <Image
+      src={icons.welcome}
       class="hidden lg:block h-auto max-h-[520px] w-full max-w-md mx-auto lg:max-w-xl"
       loading="lazy"
       alt="Ilustración de clúster de servidores"
+      sizes="(max-width: 1280px) 50vw, 40vw"
     />
   </div>
 </section>

--- a/src/components/landing/Section2.astro
+++ b/src/components/landing/Section2.astro
@@ -1,5 +1,6 @@
 ---
 import Button from "../ui/Button.astro";
+import { Image } from "astro:assets";
 import { icons } from "../../assets/icons";
 ---
 
@@ -20,7 +21,13 @@ import { icons } from "../../assets/icons";
         <div class="relative pl-16">
           <dt class="text-base/7 font-semibold text-gray-900">
             <div class="absolute top-0 left-0 flex size-10 items-center justify-center rounded-lg bg-red-800">
-              <img src={icons.loading.src} class="p-2" loading="lazy" alt="Icono cargando" />
+              <Image
+                src={icons.loading}
+                class="p-2"
+                loading="lazy"
+                alt="Icono cargando"
+                sizes="40px"
+              />
             </div>
             Administración de Sistemas
           </dt>
@@ -36,7 +43,13 @@ import { icons } from "../../assets/icons";
         <div class="relative pl-16">
           <dt class="text-base/7 font-semibold text-gray-900">
             <div class="absolute top-0 left-0 flex size-10 items-center justify-center rounded-lg bg-red-800">
-              <img src={icons.lock.src} class="p-2" loading="lazy" alt="Icono candado" />
+              <Image
+                src={icons.lock}
+                class="p-2"
+                loading="lazy"
+                alt="Icono candado"
+                sizes="40px"
+              />
             </div>
             Hospedaje Web Profesional
           </dt>
@@ -52,7 +65,13 @@ import { icons } from "../../assets/icons";
         <div class="relative pl-16">
           <dt class="text-base/7 font-semibold text-gray-900">
             <div class="absolute top-0 left-0 flex size-10 items-center justify-center rounded-lg bg-red-800">
-              <img src={icons.cloud.src} class="p-2" loading="lazy" alt="Icono nube" />
+              <Image
+                src={icons.cloud}
+                class="p-2"
+                loading="lazy"
+                alt="Icono nube"
+                sizes="40px"
+              />
             </div>
             Servicios en la Nube
           </dt>
@@ -68,7 +87,13 @@ import { icons } from "../../assets/icons";
         <div class="relative pl-16">
           <dt class="text-base/7 font-semibold text-gray-900">
             <div class="absolute top-0 left-0 flex size-10 items-center justify-center rounded-lg bg-red-800">
-              <img src={icons.finger.src} class="p-2" loading="lazy" alt="Icono huella" />
+              <Image
+                src={icons.finger}
+                class="p-2"
+                loading="lazy"
+                alt="Icono huella"
+                sizes="40px"
+              />
             </div>
             Mantenimiento de Software y Hardware
           </dt>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,7 @@
 ---
 import { seoConfig } from "@/config/seo-config";
 import Layout from "@/layouts/Layout.astro";
+import { Image } from "astro:assets";
 import { icons } from "../assets/icons";
 import about from "../assets/images/about/about.svg";
 ---
@@ -40,7 +41,7 @@ import about from "../assets/images/about/about.svg";
         </div>
       </div>
       <div class="lg:sticky lg:top-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:overflow-hidden lg:pt-15">
-        <img src={about.src} alt="about background" />
+        <Image src={about} alt="about background" sizes="(max-width: 1024px) 100vw, 50vw" />
       </div>
       <div
         class="lg:col-span-2 lg:col-start-1 lg:row-start-2 lg:mx-auto lg:grid lg:w-full lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8"
@@ -55,21 +56,21 @@ import about from "../assets/images/about/about.svg";
             </p>
             <ul role="list" class="mt-8 space-y-8 text-gray-600">
               <li class="flex gap-x-3">
-                <img src={icons.cloudAbout.src} alt="Icono nube" class="size-10" />
+                <Image src={icons.cloudAbout} alt="Icono nube" class="size-10" sizes="40px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Gestión y despliegue eficiente.</strong> Implementamos estrategias
                   efectivas para asegurar un funcionamiento óptimo de tus sistemas tecnológicos.
                 </span>
               </li>
               <li class="flex gap-x-3">
-                <img src={icons.lockAbout.src} alt="Icono candado" class="size-10" />
+                <Image src={icons.lockAbout} alt="Icono candado" class="size-10" sizes="40px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Seguridad garantizada con certificados SSL.</strong> Protegemos
                   tus datos y los de tus clientes mediante estándares de seguridad de alto nivel.
                 </span>
               </li>
               <li class="flex gap-x-3">
-                <img src={icons.driveAbout.src} alt="Icono disco ssd" class="size-10" />
+                <Image src={icons.driveAbout} alt="Icono disco ssd" class="size-10" sizes="40px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Copias de seguridad automatizadas para tus datos.</strong>
                   Aseguramos la continuidad de tu negocio con respaldos regulares y seguros.
@@ -87,21 +88,21 @@ import about from "../assets/images/about/about.svg";
             </p>
             <ul role="list" class="mt-8 space-y-8 text-gray-600">
               <li class="flex gap-x-3">
-                <img src={icons.circleAbout.src} alt="Icono circulo" class="size-8" />
+                <Image src={icons.circleAbout} alt="Icono circulo" class="size-8" sizes="32px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Consultoría especializada.</strong> Ofrecemos asesoramiento
                   técnico para identificar las mejores soluciones tecnológicas para tu negocio.
                 </span>
               </li>
               <li class="flex gap-x-3">
-                <img src={icons.circleAbout.src} alt="Icono circulo" class="size-8" />
+                <Image src={icons.circleAbout} alt="Icono circulo" class="size-8" sizes="32px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Soporte técnico 24/7.</strong> Nuestro equipo está disponible
                   en todo momento para resolver cualquier incidencia o consulta técnica.
                 </span>
               </li>
               <li class="flex gap-x-3">
-                <img src={icons.circleAbout.src} alt="Icono circulo" class="size-8" />
+                <Image src={icons.circleAbout} alt="Icono circulo" class="size-8" sizes="32px" />
                 <span>
                   <strong class="font-semibold text-gray-900">Integración de sistemas.</strong> Facilitamos la conexión entre
                   diferentes plataformas y herramientas para optimizar tus procesos.

--- a/src/pages/contact/success.astro
+++ b/src/pages/contact/success.astro
@@ -2,6 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import { seoConfig } from "../../config/seo-config";
 import Button from "../../components/ui/Button.astro";
+import { Image } from "astro:assets";
 import { icons } from "../../assets/icons";
 ---
 
@@ -14,7 +15,12 @@ import { icons } from "../../assets/icons";
   <section class="min-h-[70vh] flex flex-col justify-center items-center text-center px-6 py-24 bg-gray-50">
     <div class="max-w-xl w-full">
       <div class="flex justify-center mb-8">
-        <img src={icons.successContact.src} alt="Mensaje enviado correctamente" class="w-44 h-44" />
+        <Image
+          src={icons.successContact}
+          alt="Mensaje enviado correctamente"
+          class="w-44 h-44"
+          sizes="11rem"
+        />
       </div>
       <h1 class="text-4xl font-bold text-gray-800 mb-4">¡Mensaje enviado con éxito!</h1>
       <p class="text-lg text-gray-700 mb-6 pb-10">


### PR DESCRIPTION
## Summary
- enable responsive images with Astro's `<Image>` component
- replace `<img>` tags with `<Image>` in the landing sections, footer and other pages

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5ce4f23c832ea115908a9dfd3474